### PR TITLE
I18n l10n add localisation through internationalisation support

### DIFF
--- a/lib/i18n/date/get_universal_datetime_iso_8601_z_string.dart
+++ b/lib/i18n/date/get_universal_datetime_iso_8601_z_string.dart
@@ -1,0 +1,3 @@
+String getUniversalDateTimeIso8601ZString(DateTime datetime) {
+  return datetime.toUtc().toIso8601String();
+}

--- a/lib/i18n/localisation/australian/australian_localisation_delegate.dart
+++ b/lib/i18n/localisation/australian/australian_localisation_delegate.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/foundation.dart' show SynchronousFuture;
+import 'package:flutter/material.dart'
+    show
+        DefaultMaterialLocalizations,
+        Locale,
+        LocalizationsDelegate,
+        MaterialLocalizations;
+
+class AustralianLocalisationDelegate
+    extends LocalizationsDelegate<MaterialLocalizations> {
+  const AustralianLocalisationDelegate();
+
+  @override
+  bool isSupported(Locale locale) => locale.languageCode == 'en';
+
+  @override
+  Future<MaterialLocalizations> load(Locale locale) =>
+      SynchronousFuture<MaterialLocalizations>(
+        const CustomLocalization(),
+      );
+
+  @override
+  bool shouldReload(AustralianLocalisationDelegate old) => false;
+
+  @override
+  String toString() => 'CustomLocalization.delegate(en_AU)';
+}
+
+/// Default MaterialApp implicitly uses DefaultMaterialLocalizations delegate
+///
+/// We are now forcing our own delegate instead.
+///
+/// Override samples found here
+/// https://stackoverflow.com/questions/54518741/flutter-change-search-hint-text-of-searchdelegate
+/// - BUG: https://github.com/flutter/flutter/issues/70341
+/// Repurpose to override the dateHelpText for date mm/dd/yyyy
+class CustomLocalization extends DefaultMaterialLocalizations {
+  const CustomLocalization();
+
+  /// Unused
+  /// This search text is the same as the default.
+  @override
+  String get searchFieldLabel => 'Search';
+
+  /// We want Australian region date format.
+  ///
+  /// DefaultMaterialLocalization defaults to mm/dd/yyyy regardless of device
+  /// or other setting
+  ///
+  /// - BUG: https://github.com/flutter/flutter/issues/70341 Known Flutter bug.
+  @override
+  String get dateHelpText => 'dd/mm/yyyy';
+
+  @override
+  String formatCompactDate(DateTime date) {
+    // Assumes Aus dd/MM/yyyy rather than  US mm/dd/yyyy format
+    final day = _formatTwoDigitZeroPad(date.day);
+    final month = _formatTwoDigitZeroPad(date.month);
+    final year = date.year.toString().padLeft(4, '0');
+
+    return '$day/$month/$year';
+  }
+
+  /// Adapts Australian input and reuses existing format parsers
+  /// Check if InputDatePickerFormField form validators use this or other defaults.
+  /// e.g. `invalidDateFormatLabel` "Invalid format"
+  /// Hack into the default US region functionality
+  ///
+  /// Return Nullable
+  /// No union type support in Dart
+  /// Nullable DateTime? notation is in beta.
+  @override
+  DateTime? parseCompactDate(String? ausInputddMMyyyy) {
+    if (ausInputddMMyyyy == null) {
+      return null;
+    }
+
+    final String? rearrangedAusToUSFormat = getDateStringUSFormatFromAusFormat(
+      ausInputddMMyyyy,
+    );
+
+    // See tryParse nullability logic in base DefaultMaterialLocalizations
+    return super.parseCompactDate(rearrangedAusToUSFormat);
+  }
+}
+
+///
+String? getDateStringUSFormatFromAusFormat(String ausInputddMMyyyy) {
+  final List<String> dateParts = ausInputddMMyyyy.split('/');
+  if (dateParts.length != 3) {
+    return null;
+  }
+  final String day = dateParts[0];
+  final String month = dateParts[1];
+  final String year = dateParts[2];
+
+  // To reuse the default US logic rather than recreating
+  // This will break if Flutter ever decides to have respective region defaults.
+  final String rearrangedAusToUSFormat = '$month/$day/$year';
+
+  return rearrangedAusToUSFormat;
+}
+
+/// Formats [number] using two digits, assuming it's in the 0-99 inclusive
+/// range. Not designed to format values outside this range.
+String _formatTwoDigitZeroPad(int number) {
+  assert(0 <= number && number < 100);
+
+  if (number < 10) return '0$number';
+
+  return '$number';
+}

--- a/lib/i18n/localisation/australian/search_delegate.dart
+++ b/lib/i18n/localisation/australian/search_delegate.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+/// Unused code :fire: 🔥
+@Deprecated(
+  'For showSearch(). '
+  'Not currently using this for anything. '
+  'May have used get searchFieldLabel instead',
+)
+class DummySearchDelegate extends SearchDelegate<String> {
+  @override
+  List<Widget> buildActions(BuildContext context) => [];
+
+  @override
+  Widget buildLeading(BuildContext context) => IconButton(
+        icon: const Icon(Icons.close),
+        onPressed: () => Navigator.of(context).pop(),
+      );
+
+  @override
+  Widget buildResults(BuildContext context) => const Text('Result');
+
+  @override
+  Widget buildSuggestions(BuildContext context) => const Text('Suggestion');
+}
+
+@Deprecated(
+  'For showSearch(). '
+  'Not currently using this for anything. '
+  'May have used get searchFieldLabel instead',
+)
+class DummySearchSampleDelegate extends SearchDelegate<String> {
+  DummySearchSampleDelegate({
+    String hintText = 'Sample search hint',
+  }) : super(
+          searchFieldLabel: hintText,
+          keyboardType: TextInputType.text,
+          textInputAction: TextInputAction.search,
+        );
+
+  @override
+  List<Widget> buildActions(BuildContext context) {
+    return [];
+  }
+
+  @override
+  Widget buildLeading(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.close),
+      onPressed: () => Navigator.of(context).pop(),
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) => const Text('Result');
+
+  @override
+  Widget buildSuggestions(BuildContext context) => const Text('Suggestion');
+}

--- a/lib/my_app.dart
+++ b/lib/my_app.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart'
+    show GlobalMaterialLocalizations, GlobalWidgetsLocalizations;
 import 'package:testable_web_app/boilerplate/my_home_page.dart' show MyHomePage;
+import 'package:testable_web_app/i18n/localisation/australian/australian_localisation_delegate.dart'
+    show AustralianLocalisationDelegate;
 
 class MyApp extends StatelessWidget {
   const MyApp({
@@ -11,6 +15,15 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter webstore portal demo app',
+      localizationsDelegates: const [
+        AustralianLocalisationDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en', 'AU'), // English (Australia)
+        Locale('en', 'US'), // English (United States) for safe defaults
+      ],
       theme: ThemeData(
         // This is the theme of your application.
         //

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -237,6 +237,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -270,6 +275,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   bloc: ^7.0.0
   cupertino_icons: ^1.0.2
   equatable: ^2.0.0
   flutter_bloc: ^7.0.0
+  intl: ^0.17.0
   json_annotation: ^4.0.1
 
 dev_dependencies:


### PR DESCRIPTION
ironically localization internationalization is locale-specific spelling of the terms.


To provide a measure of control in case default United States format pops up later in development.